### PR TITLE
서치바 컴포넌트 구현

### DIFF
--- a/src/app/(with-searchbar)/layout.tsx
+++ b/src/app/(with-searchbar)/layout.tsx
@@ -1,9 +1,11 @@
+import Searchbar from '@/app/components/searchbar';
+
 import { ReactNode } from 'react';
 
 export default function Layout({ children }: { children: ReactNode }) {
   return (
     <div>
-      <div>Searchbar Layout</div>
+      <Searchbar />
       {children}
     </div>
   );

--- a/src/app/components/searchbar.tsx
+++ b/src/app/components/searchbar.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+
+export default function Searchbar() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [search, setSearch] = useState('');
+
+  const q = searchParams.get('q');
+
+  useEffect(() => {
+    setSearch(q || '');
+  }, [q]);
+
+  const onChangeSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearch(e.target.value);
+  };
+
+  const onSubmit = (e: React.ChangeEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    if (!search || q === search) return;
+    router.push(`/search?q=${search}`);
+  };
+
+  return (
+    <div>
+      <form onSubmit={onSubmit}>
+        <input value={search} onChange={onChangeSearch} placeholder="검색어를 입력하세요" />
+        <button>검색</button>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
## 작업 설명
1. 서치바 레이아웃 컴포넌트의 자식 컴포넌트로 서치바 컴포넌트 구현
2. 검색어를 입력한 다음 검색 버튼을 클릭하면 `~/search?q={검색어}` 페이지로 이동
3. 서치바 컴포넌트의 input 태그는 현재의 쿼리 스트링 q의 값을 초기값으로 갖도록 구현

## 스크린샷
![image](https://github.com/user-attachments/assets/81b0cd29-d88a-4aac-ada1-92e4d060905c)
