### PR TITLE
페이지 데이터 페칭 설정

### DIFF
--- a/src/app/(with-searchbar)/page.tsx
+++ b/src/app/(with-searchbar)/page.tsx
@@ -1,4 +1,4 @@
-import movies from '@/mock/dummy.json';
+import { MovieData } from '@/types';
 
 import style from './page.module.css';
 import classNames from 'classnames/bind';
@@ -7,24 +7,52 @@ import MovieItem from '@/components/movie-item';
 
 const cx = classNames.bind(style);
 
+async function AllMovies() {
+  const response = await fetch(`${process.env.NEXT_PUBLIC_API_SERVER_URL}/movie`, {
+    cache: 'force-cache',
+  });
+  if (!response.ok) {
+    return <div>오류가 발생했습니다...</div>;
+  }
+
+  const allMovies: MovieData[] = await response.json();
+  return (
+    <div className={cx('all_container')}>
+      {allMovies.map((movie) => (
+        <MovieItem key={`all-${movie.id}`} {...movie} />
+      ))}
+    </div>
+  );
+}
+
+async function RecoMovies() {
+  const response = await fetch(`${process.env.NEXT_PUBLIC_API_SERVER_URL}/movie/random`, {
+    next: { revalidate: 60 },
+  });
+  if (!response.ok) {
+    return <div>오류가 발생했습니다...</div>;
+  }
+
+  const recoMovies: MovieData[] = await response.json();
+  return (
+    <div className={cx('reco_container')}>
+      {recoMovies.map((movie) => (
+        <MovieItem key={`reco-${movie.id}`} {...movie} />
+      ))}
+    </div>
+  );
+}
+
 export default function Home() {
   return (
     <div className={cx('container')}>
       <section>
         <h3>지금 가장 추천하는 영화</h3>
-        <div className={cx('reco_container')}>
-          {movies.slice(0, 3).map((movie) => (
-            <MovieItem key={`reco-${movie.id}`} {...movie} />
-          ))}
-        </div>
+        <RecoMovies />
       </section>
       <section>
         <h3>등록된 모든 영화</h3>
-        <div className={cx('all_container')}>
-          {movies.map((movie) => (
-            <MovieItem key={`all-${movie.id}`} {...movie} />
-          ))}
-        </div>
+        <AllMovies />
       </section>
     </div>
   );

--- a/src/app/(with-searchbar)/search/page.tsx
+++ b/src/app/(with-searchbar)/search/page.tsx
@@ -1,4 +1,4 @@
-import movies from '@/mock/dummy.json';
+import { MovieData } from '@/types';
 
 import style from './page.module.css';
 import classNames from 'classnames/bind';
@@ -7,7 +7,23 @@ import MovieItem from '@/components/movie-item';
 
 const cx = classNames.bind(style);
 
-export default function Page() {
+export default async function Page({
+  searchParams,
+}: {
+  searchParams: {
+    q?: string;
+  };
+}) {
+  const response = await fetch(
+    `${process.env.NEXT_PUBLIC_API_SERVER_URL}/movie/search?q=${searchParams.q}`,
+  );
+
+  if (!response.ok) {
+    return <div>오류가 발생했습니다...</div>;
+  }
+
+  const movies: MovieData[] = await response.json();
+
   return (
     <div className={cx('container')}>
       {movies.map((movie) => (

--- a/src/app/movie/[id]/page.tsx
+++ b/src/app/movie/[id]/page.tsx
@@ -1,13 +1,21 @@
-import movies from '@/mock/dummy.json';
-
 import style from './page.module.css';
 import classNames from 'classnames/bind';
 
 const cx = classNames.bind(style);
 
-export default function Page() {
-  const { id, title, subTitle, company, runtime, description, posterImgUrl, releaseDate, genres } =
-    movies[3];
+export default async function Page({ params }: { params: { id: string | string[] } }) {
+  const response = await fetch(`${process.env.NEXT_PUBLIC_API_SERVER_URL}/movie/${params.id}`, {
+    cache: 'force-cache',
+  });
+
+  if (!response.ok) {
+    return <div>오류가 발생했습니다...</div>;
+  }
+
+  const movie = await response.json();
+
+  const { title, subTitle, company, runtime, description, posterImgUrl, releaseDate, genres } =
+    movie;
 
   return (
     <div className={cx('container')}>


### PR DESCRIPTION
## 작업 설명
1. 메인 페이지(모든 영화) : 거의 변화가 없으므로 항상 캐싱되는 `{ cache: 'force-cache' }` 적용
2. 메인 페이지(추천 영화) : 데이터가 변경되어야 하지만 너무 자주 바뀌면 성능 측면과 사용자 관점에서 좋지 않기 때문에 캐싱되지만 60초 주기로 업데이트 되는 `{ next: { revalidate:60 } }` 적용
3. 서치 페이지 : 검색한 값에 따라 계속 데이터가 변하므로 캐싱되지 않는 기본값으로 놔둠
4. 영화 상세 페이지 : 변화가 없으므로 항상 캐싱되는 `{ cache: 'force-cache' }` 적용
