### PR TITLE
페이지 Full Route Cache 적용

### DIFF
--- a/src/app/(with-searchbar)/layout.tsx
+++ b/src/app/(with-searchbar)/layout.tsx
@@ -1,11 +1,13 @@
-import { ReactNode } from 'react';
+import { ReactNode, Suspense } from 'react';
 
 import Searchbar from '@/components/searchbar';
 
 export default function Layout({ children }: { children: ReactNode }) {
   return (
     <div>
-      <Searchbar />
+      <Suspense fallback={<div>Loading...</div>}>
+        <Searchbar />
+      </Suspense>
       {children}
     </div>
   );

--- a/src/app/(with-searchbar)/search/page.tsx
+++ b/src/app/(with-searchbar)/search/page.tsx
@@ -16,6 +16,7 @@ export default async function Page({
 }) {
   const response = await fetch(
     `${process.env.NEXT_PUBLIC_API_SERVER_URL}/movie/search?q=${searchParams.q}`,
+    { cache: 'force-cache' },
   );
 
   if (!response.ok) {

--- a/src/app/movie/[id]/page.tsx
+++ b/src/app/movie/[id]/page.tsx
@@ -1,7 +1,20 @@
+import { MovieData } from '@/types';
+
 import style from './page.module.css';
 import classNames from 'classnames/bind';
+import { notFound } from 'next/navigation';
 
 const cx = classNames.bind(style);
+
+export const dynamicParams = false;
+
+export async function generateStaticParams() {
+  const response = await fetch(`${process.env.NEXT_PUBLIC_API_SERVER_URL}/movie`);
+
+  const movies: MovieData[] = await response.json();
+
+  return movies.map(({ id }) => ({ id: id.toString() }));
+}
 
 export default async function Page({ params }: { params: { id: string | string[] } }) {
   const response = await fetch(`${process.env.NEXT_PUBLIC_API_SERVER_URL}/movie/${params.id}`, {
@@ -9,6 +22,10 @@ export default async function Page({ params }: { params: { id: string | string[]
   });
 
   if (!response.ok) {
+    if (response.status === 404) {
+      notFound();
+    }
+
     return <div>오류가 발생했습니다...</div>;
   }
 


### PR DESCRIPTION
## 작업 설명
1. useSearchParams를 사용하는 서치바 컴포넌트는 빌드 시 오류가 생겨 Suspense 컴포넌트를 사용해 해결
2. 그 외의 인덱스 페이지, 영화 상세 페이지는 정적 페이지로 설정하여 Full Route Cache 적용

## 스크린샷
![image](https://github.com/user-attachments/assets/3a519d9c-5be7-4aff-a163-082619bcc081)
